### PR TITLE
Adding message_id

### DIFF
--- a/email.proto
+++ b/email.proto
@@ -14,4 +14,6 @@ message EmailDocument {
   string from_email = 4;
   // parsed email body
   string content = 5;
+  // email `message_id` value
+  string message_id = 6;
 }


### PR DESCRIPTION
message_id is required to generate in_reply_to and references when sending a new email.