### PR TITLE
removed optional keyword

### DIFF
--- a/email.proto
+++ b/email.proto
@@ -99,6 +99,7 @@ message SendEmailDocument {
   // previous email's html content
   string previous_html_content = 13;
 
-  // scheduled time to send email, unix timestamp
-  optional int64 scheduled_time = 14;
+  // scheduled time to send email, leave empty for immediate sending, unix
+  // timestamp
+  int64 scheduled_time = 14;
 }


### PR DESCRIPTION
rust protofish::context::Context fail to parse optional fields